### PR TITLE
Handle container snapshot devices matching both "snap" and "ctrstub"

### DIFF
--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -532,11 +532,10 @@ pub fn restore_from_snapshot(
     for i in 0..2 {
         // We assume that one of the block devices is the rootfs, the other being the
         // container image snapshot.
-        if microvm_state.device_states.block_devices[i]
+        let disk_path = &microvm_state.device_states.block_devices[i]
             .device_state
-            .disk_path
-            .contains("snap")
-        {
+            .disk_path;
+        if disk_path.contains("snap") || disk_path.contains("ctrstub") {
             microvm_state.device_states.block_devices[i]
                 .device_state
                 .disk_path = container_snapshot_path.clone();


### PR DESCRIPTION
## Changes

- Previously, we matched block devices whose disk path contained "snap" to identify the container snapshot device and substitute its path with the new container snapshot path during restore.
- This logic is extended to also match disk paths containing "ctrstub", which is the default name prefix used by other snapshotters (e.g., `ctrstub0`) when creating container stub drives.

## Reason

Previously, the code worked correctly for the **devmapper** snapshotter, where snapshots were always mounted under a predictable single device name `/dev/mapper/fc-thinpool-snap-X`, which included "snap".
However, when using other snapshotters (e.g., stargz), the container snapshot drive is named using the `ctrstubX ` convention (see [drive_handler.go#L58](https://github.com/vhive-serverless/firecracker-containerd/blob/master/runtime/drive_handler.go#L58)).

**Usage**: https://github.com/andre-j3sus/vHive/blob/feat/stargz-support-firecracker/ctriface/iface.go#L546-L580

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following
Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md